### PR TITLE
Apply patch for parseState.ResultRange

### DIFF
--- a/src/FSharp.PowerPack/Parsing.fs
+++ b/src/FSharp.PowerPack/Parsing.fs
@@ -379,6 +379,9 @@ module Implementation =
 #if DEBUG
                     if Flags.debug then Console.Write("reduce popping {0} values/states, lookahead {1}", n, report haveLookahead lookaheadToken);
 #endif
+                    
+                    lhsPos.[0] <- Position.Empty;                                                                     
+                    lhsPos.[1] <- Position.Empty;  
                     for i = 0 to n - 1 do                                                                             
                         if valueStack.IsEmpty then failwith "empty symbol stack";
                         let topVal = valueStack.Peep()
@@ -387,17 +390,10 @@ module Implementation =
                         ruleValues.[(n-i)-1] <- topVal.value;  
                         ruleStartPoss.[(n-i)-1] <- topVal.startPos;  
                         ruleEndPoss.[(n-i)-1] <- topVal.endPos;  
-                        if i = 0 then lhsPos.[1] <- topVal.endPos;                                     
-                        if i = n - 1 then lhsPos.[0] <- topVal.startPos
-                    done;                                                                                             
-                    // Use the lookahead token to populate the locations if the rhs is empty                        
-                    if n = 0 then 
-                        if haveLookahead then 
-                           lhsPos.[0] <- lookaheadStartPos;                                                                     
-                           lhsPos.[1] <- lookaheadEndPos;                                                                       
-                        else 
-                           lhsPos.[0] <- lexbuf.StartPos;
-                           lhsPos.[1] <- lexbuf.EndPos;
+                        if lhsPos.[1] = Position.Empty then lhsPos.[1] <- topVal.endPos;
+                        if not (topVal.startPos = Position.Empty) then lhsPos.[0] <- topVal.startPos
+                    done;                                                                                           
+                    
                     try                                                                                               
                           // Printf.printf "reduce %d\n" prod;                                                       
                         let redResult = reduction parseState                                                          


### PR DESCRIPTION
See patches at http://fsharppowerpack.codeplex.com/SourceControl/list/patches

This patch replaces default behaviour of FsYacc's parseState.ResultRange and other lexing positions. FsYacc binds position of lookahead token to result range if right side of the rule was empty. In some cases such behaviour isn't correct. For example:

start: rule1 TOKEN4 { $1 }
rule1: TOKEN1 TOKEN2 rule2 { parseState.ResultRange } 
rule2: TOKEN3 { }
 | { }

Patch considers position of empty productions to be Lexing.Position.Empty.
So, without the patch, if rule2 evaluates to empty, result of rule1 for input [TOKEN1 TOKEN2 TOKEN4] will be range from TOKEN1 to TOKEN4 instead of expected range from TOKEN1 to TOKEN2. 
