### PR TITLE
Changed TargetFrameworkVersion for FsYacc to v4.0

### DIFF
--- a/src/FsYacc/FsYacc.fsproj
+++ b/src/FsYacc/FsYacc.fsproj
@@ -21,7 +21,7 @@
     <!-- 5310 tracks reenabling -->
     <DefineConstants>INTERNALIZED_POWER_PACK;$(DefineConstants)</DefineConstants>
     <AllowCrossTargeting>true</AllowCrossTargeting>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <!-- These dummy entries are needed for F# Beta2 -->


### PR DESCRIPTION
In order to fix
FSYACC: error FSY000: Method not found: 'System.Type.op_Equality'.
on mono for Linux.
